### PR TITLE
Initial working zfs-storage role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,94 @@
-# Role Name
+# zfs-vm-storage
 
-A brief description of the role goes here.
+This role sets up a storage server to share ZFS filesystems via NFS or ZFS ZVOLs via iSCSI.
 
 
 ## Requirements
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+an apt-based package manager with source version 16.04 or later, as zfs isn't included in older versions.
 
 
 ## Role Variables
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+This role has four main variables: `root_prefix` sets a prefix filesystem that is applied to all filesystems and zvols (Default: `tank`). `defaults`, `filesystems`, `zvols` are described in the following sections.
 
-```yml
-```
+###defaults
+`defaults` expects a dict defining groups containing zfs attributes. This way, different default zfs attributes can be used for different filesystems/zvols. Each dict entry has a `name` variable and a `attributes` dict defining zfs attributes (using the same keys and values as ZFS does).
 
+###filesystems
+`filesystems` is a dict that contains zfs filesystems and their attributes. Each filesystem can have the following variables:
+`name` (mandatory) - the filesystem name (`root_prefix` will be prepended). Missing parent filesystems will be created without any specific zfs attributes set.
+`default_groups` is a list of default groups defined above in `default`. Attributes defined in multiple groups will be overridden using the list ordering.
+`attributes` is a dict that contains attributes that should be set, overriding the defaults. Again, keys and values are adopted directly.
+
+###zvols
+`zvols` is a dict that contains ZVOL configurations. Each entry has the following variables:
+	`name` (mandatory) - the zvol name. `root_prefix` will again be applied and missing parent filesystems created. This name is used as iSCSI target name, if `initator_name` is set.
+	`default_groups` - usage see above
+	`attributes` - usage see above
+	`initiator_name` (needed for iSCSI) - name of the iSCSI initiator that is allowed to connect to this target
+	`iscsi_ip` (Default: `172.0.0.1`) - IP of the local interface where iSCSI should be advertised
+
+Note: The size of every zvol needs to be specified using the zfs attribute `volsize`.
 
 ## Dependencies
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+None
 
 
 ## Example Playbook
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-
 ### Playbook
 
 ```yml
+- hosts: zfsstorage
+  roles:
+    - role: zfs-vm-storage
+      root_prefix: "tank/vms"
+      defaults:
+        zfs:
+          compression: "lz4"
+          acltype: "posixacl"
+        vm-fs:
+          reservation: "10G"
+        vm-image:
+          volsize: "20G"
+          volblocksize: "4K"
+      filesystems:
+        - name: "testing"
+          attributes:
+            - quota: "500G"
+          default_groups:
+            - zfs
+        - name: "testing/wiki"
+          attributes:
+            - sharenfs: "rw=@172.100.100.100"
+          default_groups:
+            - zfs
+            - vm-fs
+      zvols:
+        - name: "testing/dns01"
+          default_groups:
+            - zfs
+            - vm-image
+          initiator_name: "iqn.2005-03.org.open-iscsi:9e9c13ff76ac"
+          iscsi_ip: "172.100.100.99"
+        - name: "testing/ldap01"
+          default_groups:
+            - zfs
+            - vm-image
+          attributes:
+            - volsize: "100G"
+          initiator_name: "iqn.2005-03.org.open-iscsi:9e9c13ff76ac"
+          iscsi_ip: "172.100.100.99"
 ```
-
-
-### Vars
-
-```yml
-```
-
 
 ### Result
 
-A short summary what the playbook actually does.
+This example defines three default groups, two filesystems and two zvols. The `zfs` group is used by all filesystems and zvols and specifies the compression and acl type to be used. The other two default groups define quota/reservation defaults for filesystems (`vm-fs`) and volume size and blocksize for zvols (`vm-image`).
+
+Two filesystems are created: `testing/wiki` is exported with read and write access, usable by `172.27.100.100`. The `testing` filesystem would normally be created automatically, if `testing/wiki` is specified, but in this case we want to set further attributes, namely the quota of 500G (applying to all children of `testing`).
+Two zvols are created and exported to the same initiator, and on the same local IP `172.27.100.99`. `testing/dns01` uses the default values for zvols defined in the `vm-image` group. `testing/ldap01` also uses them, but overrides the volsize with the value `100G`.
 
 
 ## License
@@ -50,4 +98,4 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 Inter
 
 ## Author Information
 
- * [Author Name (nickname)](github profile) _your-full-stuvus-email-address@stuvus.uni-stuttgart.de_
+ * [Michel Weitbrecht (SlothOfAnarchy)](https://github.com/SlothOfAnarchy) _michel.weitbrecht@stuvus.uni-stuttgart.de_

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ zfs, nfs
 - hosts: zfsstorage
   roles:
     - role: zfs-vm-storage
-      parent_fs: tank/test
+      parent_fs: tank
       defaults:
         acltype: posixacl
         volsize: 50G
+        quota: 50G
       filesystems:
         - name: testing
           attributes:
-            acltype: noacl
+            quota: 200G
         - name: testing/wiki
           attributes:
             sharenfs: rw=@172.27.10.13
@@ -54,8 +55,8 @@ zfs, nfs
 ### Result
 
 This example creates two filesystems and two zvols.
-`tank/testing` has `acltype`=`noacl`
-`tank/testing/wiki` has `acltype`=`posixacl`, `sharenfs`=`rw=@172.27.10.13`, `compression`=`off`
+`tank/testing` has `acltype`=`posixacl`, `quota`=`200G`
+`tank/testing/wiki` has `acltype`=`posixacl`, `sharenfs`=`rw=@172.27.10.13`, `compression`=`off`, `quota`=`50G`
 `tank/testing/dns01` has `volsize`=`100G`
 `tank/testing/ldap01` has `volsize`=`50G`
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ zfs, nfs
 
 ### Result
 
-This example creates two filesystems and two zvols.
-`tank/testing` has `acltype`=`posixacl`, `quota`=`200G`
-`tank/testing/wiki` has `acltype`=`posixacl`, `sharenfs`=`rw=@172.27.10.13`, `compression`=`off`, `quota`=`50G`
-`tank/testing/dns01` has `volsize`=`100G`
-`tank/testing/ldap01` has `volsize`=`50G`
+| Name                  | Type      | Attributes                                                                              |
+|-----------------------|-----------|-----------------------------------------------------------------------------------------|
+| `tank/testing`        | filesystem| `acltype`=`posixacl`, `quota`=`200G`                                                    |
+| `tank/testing/wiki`   | filesystem| `acltype`=`posixacl`, `sharenfs`=`rw=@172.27.10.13`, `compression`=`off`, `quota`=`50G` |
+| `tank/testing/dns01`  | zvol      | `volsize`=`100G`                                                                       |
+| `tank/testing/ldap01` | zvol      | `volsize`=`50G`                                                                          |
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zfs-vm-storage
 
-This role sets up a storage server to share ZFS filesystems via NFS or ZFS ZVOLs via iSCSI.
+This role sets up ZFS filesystem that can be shared via NFS.
 
 
 ## Requirements
@@ -12,37 +12,16 @@ an apt-based package manager with source version 16.04 or later, as zfs isn't in
 
 | Name                  | Description                                                                                 |
 |-----------------------|---------------------------------------------------------------------------------------------|
-| `root_prefix`         | prefix filesystem that is applied to all filesystems and zvols (Default: `tank`)            |
+| `parent_fs`           | existing parent zfs filesystem for all filesystems and zvols (Default: `tank`)              |
 | `defaults`            | dict containing zfs attributes that will be applied to all configured zfs filesystems/zvols |
-| `groups`              | dict of dicts containing zfs attributes                                                     |
-| `filesystems`         | list of zfs filesystem definitions, see [below](#filesystems) for details                   |
-| `zvols`               | list of zvol definitions, see [below](#zvols) for details                                   |
+| `filesystems`         | list of filesystems defined by a `name` and a dict of `attributes` (both mandatory)         |
+| `zvols`               | list of zvols defined by a `name` and a dict of `attributes` (both mandatory)               |
 
-### filesystems
-Each filesystem can define the following variables:
-
-| Name                  | Description                                                                                                                                |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `name` (mandatory)    | the filesystem name (`root_prefix` will be prepended). Missing parent filesystems will be created without any specific zfs attributes set. |
-| `groups`              | list containing the groups defined above. The zfs attributes of all groups will be applied and possibly overridden                         |
-| `attributes`          | a dict that contains attributes that should be set, overriding the defaults                                                                |
-
-### zvols
-Each entry has the following variables:
-
-| Name                  | Description                                                                            |
-|-----------------------|----------------------------------------------------------------------------------------|
-| `name` (mandatory)    | the zvol name. `root_prefix` will again be applied and missing parent filesystems created. This name is used as iSCSI target name (with illegal characters replaced by `_`), if `initator_name` is set. |
-| `groups`              | list containing the groups defined above. The zfs attributes of all groups will be applied and possibly overridden|
-| `attributes`         | a dict that contains attributes that should be set, overriding the defaults |
-| `initiator_name`         | name of the iSCSI initiator that is allowed to connect to this targets (needed for iSCSI)|
-| `iscsi_ip`         | IP of the local interface where iSCSI should be advertised (Default: `172.0.0.1`)|
-
-Note: The size of every zvol needs to be specified using the zfs attribute `volsize`.
+Note: There are some zfs attributes that can only be set at creation. Also, `volsize` is a mandatory attribute for zvols.
 
 ## Dependencies
 
-None
+zfs, nfs
 
 ## Example Playbook
 
@@ -52,46 +31,33 @@ None
 - hosts: zfsstorage
   roles:
     - role: zfs-vm-storage
-      root_prefix: "tank/vms"
+      parent_fs: tank/test
       defaults:
-        compression: "lz4"
-        acltype: "posixacl"
-      groups:
-        vm-fs:
-          reservation: "10G"
-        vm-image:
-          volsize: "20G"
-          volblocksize: "4K"
+        acltype: posixacl
+        volsize: 50G
       filesystems:
-        - name: "testing"
+        - name: testing
           attributes:
-            - quota: "500G"
-        - name: "testing/wiki"
+            acltype: noacl
+        - name: testing/wiki
           attributes:
-            - sharenfs: "rw=@172.100.100.100"
-          groups:
-            - vm-fs
+            sharenfs: rw=@172.27.10.13
+            compression: off
       zvols:
-        - name: "testing/dns01"
-          groups:
-            - vm-image
-          initiator_name: "iqn.2005-03.org.open-iscsi:9e9c13ff76ac"
-          iscsi_ip: "172.100.100.99"
-        - name: "testing/ldap01"
-          groups:
-            - vm-image
+        - name: testing/dns01
           attributes:
-            - volsize: "100G"
-          initiator_name: "iqn.2005-03.org.open-iscsi:9e9c13ff76ac"
-          iscsi_ip: "172.100.100.99"
+            volsize: 100G
+        - name: testing/ldap01
+          attributes:
 ```
 
 ### Result
 
-This example defines three default groups, two filesystems and two zvols. The `zfs` group is used by all filesystems and zvols and specifies the compression and acl type to be used. The other two default groups define quota/reservation defaults for filesystems (`vm-fs`) and volume size and blocksize for zvols (`vm-image`).
-
-Two filesystems are created: `testing/wiki` is exported with read and write access, usable by `172.27.100.100`. The `testing` filesystem would normally be created automatically, if `testing/wiki` is specified, but in this case we want to set further attributes, namely the quota of `500G` (applying to all children of `testing`).
-Two zvols are created and exported to the same initiator, and on the same local IP `172.27.100.99`. `testing/dns01` uses the default values for zvols defined in the `vm-image` group. `testing/ldap01` also uses them, but overrides the volsize with the value `100G`.
+This example creates two filesystems and two zvols.
+`tank/testing` has `acltype`=`noacl`
+`tank/testing/wiki` has `acltype`=`posixacl`, `sharenfs`=`rw=@172.27.10.13`, `compression`=`off`
+`tank/testing/dns01` has `volsize`=`100G`
+`tank/testing/ldap01` has `volsize`=`50G`
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ an apt-based package manager with source version 16.04 or later, as zfs isn't in
 This role has four main variables: `root_prefix` sets a prefix filesystem that is applied to all filesystems and zvols (Default: `tank`). `defaults`, `filesystems`, `zvols` are described in the following sections.
 
 ### defaults
-`defaults` expects a dict defining groups containing zfs attributes. This way, different default zfs attributes can be used for different filesystems/zvols. Each dict entry has a `name` variable and a `attributes` dict defining zfs attributes (using the same keys and values as ZFS does).
+`defaults` expects a dict of dicts containing zfs attributes. This way, different default zfs attributes can be used for different filesystems/zvols. 
 
 ### filesystems
-`filesystems` is a dict that contains zfs filesystems and their attributes. Each filesystem can have the following variables:
+`filesystems` is a list that contains zfs filesystems with their groups and attributes. Each entry can have the following variables:
 `name` (mandatory) - the filesystem name (`root_prefix` will be prepended). Missing parent filesystems will be created without any specific zfs attributes set.
 `default_groups` is a list of default groups defined above in `default`. Attributes defined in multiple groups will be overridden using the list ordering.
 `attributes` is a dict that contains attributes that should be set, overriding the defaults. Again, keys and values are adopted directly.
 
 ### zvols
-`zvols` is a dict that contains ZVOL configurations. Each entry has the following variables:
+`zvols` is a list that contains ZVOL configurations. Each entry has the following variables:
 	`name` (mandatory) - the zvol name. `root_prefix` will again be applied and missing parent filesystems created. This name is used as iSCSI target name, if `initator_name` is set.
 	`default_groups` - usage see above
 	`attributes` - usage see above
@@ -87,7 +87,7 @@ None
 
 This example defines three default groups, two filesystems and two zvols. The `zfs` group is used by all filesystems and zvols and specifies the compression and acl type to be used. The other two default groups define quota/reservation defaults for filesystems (`vm-fs`) and volume size and blocksize for zvols (`vm-image`).
 
-Two filesystems are created: `testing/wiki` is exported with read and write access, usable by `172.27.100.100`. The `testing` filesystem would normally be created automatically, if `testing/wiki` is specified, but in this case we want to set further attributes, namely the quota of 500G (applying to all children of `testing`).
+Two filesystems are created: `testing/wiki` is exported with read and write access, usable by `172.27.100.100`. The `testing` filesystem would normally be created automatically, if `testing/wiki` is specified, but in this case we want to set further attributes, namely the quota of `500G` (applying to all children of `testing`).
 Two zvols are created and exported to the same initiator, and on the same local IP `172.27.100.99`. `testing/dns01` uses the default values for zvols defined in the `vm-image` group. `testing/ldap01` also uses them, but overrides the volsize with the value `100G`.
 
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ an apt-based package manager with source version 16.04 or later, as zfs isn't in
 
 This role has four main variables: `root_prefix` sets a prefix filesystem that is applied to all filesystems and zvols (Default: `tank`). `defaults`, `filesystems`, `zvols` are described in the following sections.
 
-###defaults
+### defaults
 `defaults` expects a dict defining groups containing zfs attributes. This way, different default zfs attributes can be used for different filesystems/zvols. Each dict entry has a `name` variable and a `attributes` dict defining zfs attributes (using the same keys and values as ZFS does).
 
-###filesystems
+### filesystems
 `filesystems` is a dict that contains zfs filesystems and their attributes. Each filesystem can have the following variables:
 `name` (mandatory) - the filesystem name (`root_prefix` will be prepended). Missing parent filesystems will be created without any specific zfs attributes set.
 `default_groups` is a list of default groups defined above in `default`. Attributes defined in multiple groups will be overridden using the list ordering.
 `attributes` is a dict that contains attributes that should be set, overriding the defaults. Again, keys and values are adopted directly.
 
-###zvols
+### zvols
 `zvols` is a dict that contains ZVOL configurations. Each entry has the following variables:
 	`name` (mandatory) - the zvol name. `root_prefix` will again be applied and missing parent filesystems created. This name is used as iSCSI target name, if `initator_name` is set.
 	`default_groups` - usage see above

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Note: There are some zfs attributes that can only be set at creation. Also, `vol
 
 ## Dependencies
 
-zfs, nfs
-
 ## Example Playbook
 
 ### Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+parent_fs: tank
+zfs_defaults:
+  aclinherit: restricted
+  acltype: noacl
+  atime: on
+  canmount: on
+  checksum: on
+  compression: on
+  copies: 1
+  dedup: off
+  devices: on
+  exec: on
+  filesystem_limit: none
+  logbias: latency
+  mountpoint: none
+  nbmand: off
+  overlay: off
+  primarycache: all
+  quota: none
+  snapshot_limit: none
+  readonly: off
+  recordsize: 128K
+  redundant_metadata: all
+  refquota:  none
+  refreservation: none
+  relatime: off
+  reservation: none
+  secondarycache: all
+  setuid: on
+  sharesmb: off
+  sharenfs: off
+  snapdev: hidden
+  snapdir: hidden
+  sync: standard
+  vscan: off
+  xattr: on

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,11 @@
 galaxy_info:
   author: Michel Weitbrecht
-  description: Sets up a zfs storage server to share filesystems via NFS or zvols via iSCSI
+  description: Configures ZFS filesystems and ZVOLs that can be shared via NFS
   company: stuvus (https://stuvus.uni-stuttgart.de)
 
   license: CC-BY-SA
 
-  min_ansible_version: 2.2
+  min_ansible_version: 2.3
 
   platforms:
     - name: Ubuntu
@@ -20,6 +20,5 @@ galaxy_info:
     - zfs
     - nfs
     - zvol
-    - iscsi
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
-  author: Insert author(s) here
-  description: Insert description here
+  author: Michel Weitbrecht
+  description: Sets up a zfs storage to share filesystems via NFS
   company: stuvus (https://stuvus.uni-stuttgart.de)
 
   license: CC-BY-SA
@@ -19,6 +19,8 @@ galaxy_info:
 
   galaxy_tags:
     - stuvus
-    - Insert ansible galaxy tags here
+    - zfs
+    - nfs
+    - vm
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,13 +1,11 @@
 galaxy_info:
   author: Michel Weitbrecht
-  description: Sets up a zfs storage to share filesystems via NFS
+  description: Sets up a zfs storage server to share filesystems via NFS or zvols via iSCSI
   company: stuvus (https://stuvus.uni-stuttgart.de)
 
   license: CC-BY-SA
 
   min_ansible_version: 2.2
-
-  github_branch: master
 
   platforms:
     - name: Ubuntu
@@ -21,6 +19,7 @@ galaxy_info:
     - stuvus
     - zfs
     - nfs
-    - vm
+    - zvol
+    - iscsi
 
 dependencies: []

--- a/tasks/configure_filesystems.yml
+++ b/tasks/configure_filesystems.yml
@@ -6,6 +6,7 @@
   ignore_errors: True
   register: fs_exists
 
+# this task fails when the filesystem already exists and some attribute in {utf8only, normalization, casesensitivity} is already set and has a differing value than the variables dictate. This is done because these attributes cannot be changed after creation
 - name: Fail if readonly attributes would be changed
   fail: 
     msg: "tried to change readonly zfs attribute on already-existing filesystem {{ parent_fs }}/{{ fs.name }}\n {{ansible_zfs_datasets[0]}}"

--- a/tasks/configure_filesystems.yml
+++ b/tasks/configure_filesystems.yml
@@ -1,0 +1,65 @@
+---
+- name: Gather zfs filesystem attributes for {{ parent_fs }}/{{ fs.name }}
+  zfs_facts:
+    name: "{{ parent_fs }}/{{ fs.name }}"
+    properties: "utf8only,normalization,casesensitivity"
+  ignore_errors: True
+  register: fs_exists
+
+- name: Fail if readonly attributes would be changed
+  fail: 
+    msg: "tried to change readonly zfs attribute on already-existing filesystem {{ parent_fs }}/{{ fs.name }}\n {{ansible_zfs_datasets[0]}}"
+  when: >
+    (fs_exists|succeeded) and
+    (   ((fs.attributes is defined and fs.attributes.utf8only is defined or default is defined and default.utf8only is defined) and ansible_zfs_datasets[0].utf8only != fs.attributes.utf8only |default(defaults.utf8only) |default(ansible_zfs_datasets[0].utf8only)) or
+        ((fs.attributes is defined and fs.attributes.normalization is defined or default is defined and default.normalization is defined) and ansible_zfs_datasets[0].normalization != fs.attributes.normalization |default(defaults.normalization) |default(ansible_zfs_datasets[0].normalization)) or
+        ((fs.attributes is defined and fs.attributes.casesensitivity is defined or default is defined and default.casesensitivity is defined) and ansible_zfs_datasets[0].casesensitivity != fs.attributes.casesensitivity |default(defaults.casesensitivity) |default(ansible_zfs_datasets[0].casesensitivity)))
+
+- name: Try to create filesystem {{ parent_fs }}/{{ fs.name }} and set on-creation attributes
+  zfs:
+    name: "{{ parent_fs }}/{{ fs.name }}"
+    state: present
+    utf8only: "{{ fs.attributes.utf8only|default(defaults.utf8only) |default(omit) }}"
+    normalization: "{{ fs.attributes.normalization|default(defaults.normalization) |default(omit) }}"
+    casesensitivity: "{{ fs.attributes.casesensitivity|default(defaults.casesensitivity) |default(omit) }}"
+  when: fs_exists|failed
+
+- name: Configure filesystem {{ parent_fs }}/{{ fs.name }}
+  zfs:
+    name: "{{ parent_fs }}/{{ fs.name }}"
+    state: present
+    aclinherit: "{{ fs.attributes.aclinherit |default(defaults.aclinherit) |default(zfs_defaults.aclinherit) }}"
+    acltype: "{{ fs.attributes.acltype |default(defaults.acltype) |default(zfs_defaults.acltype) }}"
+    atime: "{{ fs.attributes.atime |default(defaults.atime) |default(zfs_defaults.atime) }}"
+    canmount: "{{ fs.attributes.canmount |default(defaults.canmount) |default(zfs_defaults.canmount) }}"
+    checksum: "{{ fs.attributes.checksum |default(defaults.checksum) |default(zfs_defaults.checksum) }}"
+    compression: "{{ fs.attributes.compression |default(defaults.compression) |default(zfs_defaults.compression) }}"
+    copies: "{{ fs.attributes.copies |default(defaults.copies) |default(zfs_defaults.copies) }}"
+    dedup: "{{ fs.attributes.dedup |default(defaults.dedup) |default(zfs_defaults.dedup) }}"
+    devices: "{{ fs.attributes.devices |default(defaults.devices) |default(zfs_defaults.devices) }}"
+    exec: "{{ fs.attributes.exec |default(defaults.exec) |default(zfs_defaults.exec) }}"
+    filesystem_limit: "{{ fs.attributes.filesystem_limit |default(defaults.filesystem_limit) |default(zfs_defaults.filesystem_limit) }}"
+    logbias: "{{ fs.attributes.logbias |default(defaults.logbias) |default(zfs_defaults.logbias) }}"
+    #mountpoint is none by default
+    mountpoint: "{{ fs.attributes.mountpoint |default(defaults.mountpoint) |default(zfs_defaults.mountpoint) }}"
+    nbmand: "{{ fs.attributes.nbmand |default(defaults.nbmand) |default(zfs_defaults.nbmand) }}"
+    overlay: "{{ fs.attributes.overlay |default(defaults.overlay) |default(zfs_defaults.overlay) }}"
+    primarycache: "{{ fs.attributes.primarycache |default(defaults.primarycache) |default(zfs_defaults.primarycache) }}"
+    quota: "{{ fs.attributes.quota |default(defaults.quota) |default(zfs_defaults.quota) }}"
+    snapshot_limit: "{{ fs.attributes.snapshot_limit |default(defaults.snapshot_limit) |default(zfs_defaults.snapshot_limit) }}"
+    readonly: "{{ fs.attributes.readonly |default(defaults.readonly) |default(zfs_defaults.readonly) }}"
+    recordsize: "{{ fs.attributes.recordsize |default(defaults.recordsize) |default(zfs_defaults.recordsize) }}"
+    redundant_metadata: "{{ fs.attributes.redundant_metadata |default(defaults.redundant_metadata) |default(zfs_defaults.redundant_metadata) }}"
+    refquota: "{{ fs.attributes.refquota |default(defaults.refquota) |default(zfs_defaults.refquota) }}"
+    refreservation: "{{ fs.attributes.refreservation |default(defaults.refreservation) |default(zfs_defaults.refreservation) }}"
+    relatime: "{{ fs.attributes.relatime |default(defaults.relatime) |default(zfs_defaults.relatime) }}"
+    reservation: "{{ fs.attributes.reservation |default(defaults.reservation) |default(zfs_defaults.reservation) }}"
+    secondarycache: "{{ fs.attributes.secondarycache |default(defaults.secondarycache) |default(zfs_defaults.secondarycache) }}"
+    setuid: "{{ fs.attributes.setuid |default(defaults.setuid) |default(zfs_defaults.setuid) }}"
+    sharesmb: "{{ fs.attributes.sharesmb |default(defaults.sharesmb) |default(zfs_defaults.sharesmb) }}"
+    sharenfs: "{{ fs.attributes.sharenfs |default(defaults.sharenfs) |default(zfs_defaults.sharenfs) }}"
+    snapdev: "{{ fs.attributes.snapdev |default(defaults.snapdev) |default(zfs_defaults.snapdev) }}"
+    snapdir: "{{ fs.attributes.snapdir |default(defaults.snapdir) |default(zfs_defaults.snapdir) }}"
+    sync: "{{ fs.attributes.sync |default(defaults.sync) |default(zfs_defaults.sync) }}"
+    vscan: "{{ fs.attributes.vscan |default(defaults.vscan) |default(zfs_defaults.vscan) }}"
+    xattr: "{{ fs.attributes.xattr |default(defaults.xattr) |default(zfs_defaults.xattr) }}"

--- a/tasks/configure_zvols.yml
+++ b/tasks/configure_zvols.yml
@@ -6,6 +6,7 @@
   ignore_errors: True
   register: zvol_exists
 
+# this task fails when the zvol already exists and either volsize or volblocksize is already set and has a differing value than the variables dictate. This is done because these attributes cannot be changed after creation
 - name: Fail if readonly attributes would be changed
   fail: 
     msg: "tried to change readonly zfs attribute on already-existing filesystem {{ parent_fs }}/{{ zvol.name }}\n {{ansible_zfs_datasets[0]}}"

--- a/tasks/configure_zvols.yml
+++ b/tasks/configure_zvols.yml
@@ -1,0 +1,42 @@
+---
+- name: Gather zfs zvol attributes for {{ parent_fs }}/{{ zvol.name }}
+  zfs_facts:
+    name: "{{ parent_fs }}/{{ zvol.name }}"
+    properties: "volsize,volblocksize"
+  ignore_errors: True
+  register: zvol_exists
+
+- name: Fail if readonly attributes would be changed
+  fail: 
+    msg: "tried to change readonly zfs attribute on already-existing filesystem {{ parent_fs }}/{{ zvol.name }}\n {{ansible_zfs_datasets[0]}}"
+  when: >
+    (zvol_exists |succeeded) and
+    (((zvol.attributes is defined and zvol.attributes.volsize is defined or default is defined and default.volsize is defined) and ansible_zfs_datasets[0].volsize != zvol.attributes.volsize |default(defaults.volsize) |default(ansible_zfs_datasets[0].volsize)) or
+        (((zvol.attributes is defined and zvol.attributes.volblocksize is defined or default is defined and default.volblocksize is defined) and ansible_zfs_datasets[0].volblocksize != zvol.attributes.volblocksize |default(defaults.volblocksize) |default(ansible_zfs_datasets[0].volblocksize))))
+
+- name: Try to create zvol {{ parent_fs }}/{{ zvol.name }} and set on-creation attributes
+  zfs:
+    name: "{{ parent_fs }}/{{ zvol.name }}"
+    state: present
+    volblocksize: "{{ zvol.attributes.volblocksize |default(defaults.volblocksize) |default(omit) }}"
+    volsize: "{{ zvol.attributes.volsize |default(defaults.volsize) |mandatory }}"
+  when: zvol_exists |failed
+
+- name: Configure zvol {{ parent_fs }}/{{ zvol.name }}
+  zfs:
+    name: "{{ parent_fs }}/{{ zvol.name }}"
+    state: present
+    checksum: "{{ zvol.attributes.checksum |default(defaults.checksum) |default(zfs_defaults.checksum) }}"
+    compression: "{{ zvol.attributes.compression |default(defaults.compression) |default(zfs_defaults.compression) }}"
+    copies: "{{ zvol.attributes.copies |default(defaults.copies) |default(zfs_defaults.copies) }}"
+    dedup: "{{ zvol.attributes.dedup |default(defaults.dedup) |default(zfs_defaults.dedup) }}"
+    logbias: "{{ zvol.attributes.logbias |default(defaults.logbias) |default(zfs_defaults.logbias) }}"
+    primarycache: "{{ zvol.attributes.primarycache |default(defaults.primarycache) |default(zfs_defaults.primarycache) }}"
+    snapshot_limit: "{{ zvol.attributes.snapshot_limit |default(defaults.snapshot_limit) |default(zfs_defaults.snapshot_limit) }}"
+    readonly: "{{ zvol.attributes.readonly |default(defaults.readonly) |default(zfs_defaults.readonly) }}"
+    redundant_metadata: "{{ zvol.attributes.redundant_metadata |default(defaults.redundant_metadata) |default(zfs_defaults.redundant_metadata) }}"
+    refreservation: "{{ zvol.attributes.refreservation |default(defaults.refreservation) |default(zfs_defaults.refreservation) }}"
+    reservation: "{{ zvol.attributes.reservation |default(defaults.reservation) |default(zfs_defaults.reservation) }}"
+    secondarycache: "{{ zvol.attributes.secondarycache |default(defaults.secondarycache) |default(zfs_defaults.secondarycache) }}"
+    snapdev: "{{ zvol.attributes.snapdev |default(defaults.snapdev) |default(zfs_defaults.snapdev) }}"
+    sync: "{{ zvol.attributes.sync |default(defaults.sync) |default(zfs_defaults.sync) }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install apt packages
+- name: Install ZFS apt packages
   apt:
     name: "{{ item }}"
   with_items:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,4 +7,15 @@
     - zfs-initramfs
     - zfs-zed
     - zfs-doc
-when: ansible_pkg_mgr == "apt"
+  when: ansible_pkg_mgr == "apt"
+
+- name: Load kernel module
+  modprobe:
+    name: "zfs"
+    state: present
+
+- name: Add zfs module to /etc/modules
+  lineinfile:
+    dest: /etc/modules
+    line: 'zfs'
+    state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,10 @@
+---
+- name: Install apt packages
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - zfsutils-linux
+    - zfs-initramfs
+    - zfs-zed
+    - zfs-doc
+when: ansible_pkg_mgr == "apt"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 # tasks file for .
+- include: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,13 @@
 ---
-# tasks file for .
 - include: install.yml
+- include: configure_filesystems.yml
+  with_items: 
+    - "{{ filesystems }}"
+  loop_control:
+    loop_var: "fs"
+- include: configure_zvols.yml
+  with_items: 
+    - "{{ zvols }}"
+  loop_control:
+    loop_var: "zvol"
+- include: nfs.yml

--- a/tasks/nfs.yml
+++ b/tasks/nfs.yml
@@ -1,0 +1,22 @@
+---
+- name: Check if NFS packages are needed
+  zfs_facts:
+    name: "{{ root_prefix }}/{{ item.name }}"
+    properties: "sharenfs"
+  ignore_errors: True
+  register: no_nfs_datasets
+  with_items:
+    - "{{ filesystems }}"
+  failed_when: ansible_zfs_datasets[0].sharenfs != "off"
+
+- name: Install NFS server package
+  apt:
+    name: nfs-kernel-server
+  when: (ansible_pkg_mgr == "apt") and (no_nfs_datasets |failed)
+
+- name: Enable and (re-)start NFS server
+  service:
+    name: nfs-kernel-server.service
+    state: started
+    enabled: true
+  when: no_nfs_datasets |failed


### PR DESCRIPTION
Working role to configure zfs filesystems and zvols and share zfs filesystems via NFS.
iSCSI configuration should follow in its own role.

Note that currently each filesystem and zvol needs to define a attributes dict, even if it is empty. If someone can provide a working solution that doesn't depend on this, feel free to share or commit it.