### PR TITLE
Revert "tasks/scrub_timer.yml: Validate systemd unit files"

### DIFF
--- a/tasks/scrub_timer.yml
+++ b/tasks/scrub_timer.yml
@@ -11,7 +11,6 @@
     owner: root
     mode: 0644
     src: zpool-scrub@.service.j2
-    validate: systemd-analyze verify %s
   register: scrubservice
 
 - name: Install systemd timer file (zpool-scrub@.timer)
@@ -21,7 +20,6 @@
     owner: root
     mode: 0644
     src: zpool-scrub@.timer.j2
-    validate: systemd-analyze verify %s
   register: scrubtimer
 
 - name: Enable scrub systemd timer


### PR DESCRIPTION
Reverts stuvusIT/zfs-storage#35
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232