### PR TITLE
fix(nfs): Fix a role failure when a configured nfs share is removed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart NFS server
+  service:
+    name: nfs-kernel-server.service
+    state: restarted
+  when: ansible_service_mgr == "systemd"

--- a/tasks/install_nfs.yml
+++ b/tasks/install_nfs.yml
@@ -3,11 +3,12 @@
   apt:
     name: nfs-kernel-server
   when: ansible_pkg_mgr == "apt"
+  notify:
+    - Restart NFS server
 
-- name: Enable and start NFS server
+- name: Enable NFS server
   service:
     name: nfs-kernel-server.service
-    state: started
     enabled: True
   when: ansible_service_mgr == "systemd"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,8 @@
     when: zfs_save_nfs_exports and zfs_filesystems|json_query('[*].attributes.sharenfs')|difference([false,'off'])|length>0
     tags:
       - zfs_nfs
+    notify:
+      - Restart NFS server
 
   - name: Delete NFS exports
     file:
@@ -36,6 +38,8 @@
     when: zfs_save_nfs_exports and zfs_filesystems|json_query('[*].attributes.sharenfs')|difference([false,'off'])|length==0
     tags:
       - zfs_nfs
+    notify:
+      - Restart NFS server
 
   - include_tasks: configure_zvols.yml
     with_items:


### PR DESCRIPTION
In that case the nfs-kernel-server.service failed to restart,
aborting the execution of the whole role.
It fails because for one of the exports configured in
/etc/exports.d/zfs-storage-ansible.exports
the directory does not exist.
The zfs-storage-ansible.exports is never updated and the old export removed
because the role never gets to that point.

Now the role only restarts the service at the end,
after the zfs-storage-ansible.exports is updated